### PR TITLE
reiz.reizql: simplify unpacking of global filters

### DIFF
--- a/reiz/ir/builder.py
+++ b/reiz/ir/builder.py
@@ -34,15 +34,11 @@ class IRBuilder:
         else:
             return self.filter(left, right, operator)
 
-    def combine_multi_filters(self, left, right_filters, operator="AND"):
-        for right_filter in right_filters:
-            left = self.combine_filters(left, right_filter, operator=operator)
+    def unpack_filters(self, filters, operator="AND"):
+        left = None
+        for right in filters:
+            left = self.combine_filters(left, right)
         return left
-
-    def l_combine_multi_filters(self, left_filters, right, operator="AND"):
-        for left_filter in reversed(left_filters):
-            right = self.combine_filters(left_filter, right, operator=operator)
-        return right
 
     def merge(self, expressions):
         union = next(expressions)

--- a/reiz/reizql/compiler/codegen.py
+++ b/reiz/reizql/compiler/codegen.py
@@ -34,8 +34,8 @@ def compile_matcher(node, state):
 
     if state.is_root:
         state.scope.exit()
-        if state.filters:
-            filters = IR.l_combine_multi_filters(state.filters, filters)
+        if state_filters := IR.unpack_filters(state.filters):
+            filters = IR.combine_filters(filters, state_filters)
         if state.variables:
             namespace = IR.namespace(state.variables)
             filters = IR.add_namespace(namespace, IR.select(filters))

--- a/tests/dataset/simple/any_number_of_stmts.py
+++ b/tests/dataset/simple/any_number_of_stmts.py
@@ -1,0 +1,32 @@
+def foo():  # reiz: tp
+    ...
+
+
+def bar():  # reiz: tp
+    ...
+    try:
+        ...
+        if 1:
+            ...
+        else:
+            ...
+    except:
+        ...
+
+
+def baz():  # reiz: tp
+    pass
+    pass
+    pass
+    pass
+
+
+class T:
+    ...
+
+
+a = 1
+
+
+async def foo():
+    nooo()

--- a/tests/queries/simple/any_number_of_stmts.reizql
+++ b/tests/queries/simple/any_number_of_stmts.reizql
@@ -1,0 +1,1 @@
+FunctionDef(body=[*...])


### PR DESCRIPTION
Handling of empty local filters causes problem on the current version. This patch simplifies and unifies that logic with the current `IR.combine_filters` call in order to handle cases where the aren't any local filters (e.g `FunctionDef(body=[*...])`).