### PR TITLE
Use minified 30-day source instead of unavailable 365-day

### DIFF
--- a/reiz/sampling/get_dataset.py
+++ b/reiz/sampling/get_dataset.py
@@ -7,7 +7,7 @@ from reiz.sampling import SamplingData, dump_dataset
 from reiz.utilities import guarded, json_request, logger
 
 PYPI_INSTANCE = "https://pypi.org/pypi"
-PYPI_DATSET_URL = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json"
+PYPI_DATSET_URL = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
 
 SOURCE_LOCATIONS = frozenset(
     (


### PR DESCRIPTION
I needed to remove the 365-day data because it was using more quota than available, so let's switch to the 30-day one instead.

Also use the minified version for a bit smaller file.

Re: https://github.com/hugovk/top-pypi-packages/pull/21, https://github.com/hugovk/top-pypi-packages/pull/20, https://github.com/hugovk/top-pypi-packages/issues/19.
