### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/reiz/sampling/get_dataset.py
+++ b/reiz/sampling/get_dataset.py
@@ -7,7 +7,7 @@ from reiz.sampling import SamplingData, dump_dataset
 from reiz.utilities import guarded, json_request, logger
 
 PYPI_INSTANCE = "https://pypi.org/pypi"
-PYPI_DATSET_URL = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
+PYPI_DATSET_URL = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json"
 
 SOURCE_LOCATIONS = frozenset(
     (


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.